### PR TITLE
Refactor into per-OS jobs and more granular steps

### DIFF
--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -48,11 +48,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - name: Build and test
+      - name: Build
         shell: pwsh
         run: |
           $env:PlatformToolset = "v145"
           ./PCbuild/build.bat --tail-call-interp ${{ matrix.build_flags }} -c Release -p ${{ matrix.architecture }}
+      - name: Test
+        shell: pwsh
+        run: |
           if ("${{ matrix.run_tests }}" -eq "true") {
             ./PCbuild/rt.bat -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
           }
@@ -76,15 +79,19 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - name: Build and test
+      - name: Install dependencies
         run: |
           brew update
           brew install llvm@${{ env.LLVM_VERSION }}
+      - name: Build
+        run: |
           export SDKROOT="$(xcrun --show-sdk-path)"
           export PATH="/usr/local/opt/llvm@${{ env.LLVM_VERSION }}/bin:$PATH"
           export PATH="/opt/homebrew/opt/llvm@${{ env.LLVM_VERSION }}/bin:$PATH"
           CC=clang-${{ env.LLVM_VERSION }} ./configure --with-tail-call-interp
           make all --jobs 4
+      - name: Test
+        run: |
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   linux:
@@ -111,10 +118,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - name: Build and test
+      - name: Build
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ env.LLVM_VERSION }}
           export PATH="$(llvm-config-${{ env.LLVM_VERSION }} --bindir):$PATH"
           CC=clang-${{ env.LLVM_VERSION }} ./configure --with-tail-call-interp ${{ matrix.configure_flags }}
           make all --jobs 4
+      - name: Test
+        run: |
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -23,7 +23,7 @@ env:
   LLVM_VERSION: 21
 
 jobs:
-  tail-call:
+  windows:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -41,24 +41,6 @@ jobs:
             runner: windows-2025-vs2026
             build_flags: --disable-gil
             run_tests: false
-          - target: x86_64-apple-darwin/clang
-            architecture: x86_64
-            runner: macos-15-intel
-          - target: aarch64-apple-darwin/clang
-            architecture: aarch64
-            runner: macos-14
-          - target: x86_64-unknown-linux-gnu/gcc
-            architecture: x86_64
-            runner: ubuntu-24.04
-            configure_flags: --with-pydebug
-          - target: x86_64-unknown-linux-gnu/gcc-free-threading
-            architecture: x86_64
-            runner: ubuntu-24.04
-            configure_flags: --disable-gil
-          - target: aarch64-unknown-linux-gnu/gcc
-            architecture: aarch64
-            runner: ubuntu-24.04-arm
-            configure_flags: --with-pydebug
     steps:
       - uses: actions/checkout@v6
         with:
@@ -66,9 +48,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-
-      - name: Native Windows MSVC (release)
-        if: runner.os == 'Windows'
+      - name: Build and test
         shell: pwsh
         run: |
           $env:PlatformToolset = "v145"
@@ -77,8 +57,26 @@ jobs:
             ./PCbuild/rt.bat -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
           }
 
-      - name: Native macOS (release)
-        if: runner.os == 'macOS'
+  macos:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin/clang
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin/clang
+            runner: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Build and test
         run: |
           brew update
           brew install llvm@${{ env.LLVM_VERSION }}
@@ -89,8 +87,31 @@ jobs:
           make all --jobs 4
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-      - name: Native Linux
-        if: runner.os == 'Linux'
+  linux:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu/gcc
+            runner: ubuntu-24.04
+            configure_flags: --with-pydebug
+          - target: x86_64-unknown-linux-gnu/gcc-free-threading
+            runner: ubuntu-24.04
+            configure_flags: --disable-gil
+          - target: aarch64-unknown-linux-gnu/gcc
+            runner: ubuntu-24.04-arm
+            configure_flags: --with-pydebug
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Build and test
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ env.LLVM_VERSION }}
           export PATH="$(llvm-config-${{ env.LLVM_VERSION }} --bindir):$PATH"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.0
     hooks:
       - id: ruff-check
         name: Run Ruff (lint) on Apple/
@@ -52,14 +52,14 @@ repos:
         files: ^Tools/wasm/
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
       - id: black
         name: Run Black on Tools/jit/
         files: ^Tools/jit/
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: v1.5.6
     hooks:
       - id: remove-tabs
         types: [python]
@@ -83,19 +83,19 @@ repos:
         files: '^\.github/CODEOWNERS|\.(gram)$'
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.0
+    rev: 0.36.1
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.9
+    rev: v1.7.10
     hooks:
       - id: actionlint
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.19.0
+    rev: v1.22.0
     hooks:
       - id: zizmor
 

--- a/Tools/jit/_llvm.py
+++ b/Tools/jit/_llvm.py
@@ -10,7 +10,6 @@ import typing
 
 import _targets
 
-
 _LLVM_VERSION = "21"
 _EXTERNALS_LLVM_TAG = "llvm-21.1.4.0"
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Last suggestion for https://github.com/python/cpython/pull/144553.

Instead of a single job, with three steps (Windows, macOS, Linux) that each has a guard for `runner.os`, this PR does a job per OS instead.

That way we don't have skipped jobs when looking at the logs.

There is a bit of extra duplication, but it's only `actions/checkout` and `actions/setup-python` which are straighforward.

And now we have one job per OS, instead of a single step to do all the CI work, we can split it up into install, build and test steps.

This chunks the output, so we can more easily see _where_ failures happen. It also shows how long each step takes, which can be useful in case something starts taking longer than it should.

Before: https://github.com/python/cpython/actions/runs/21787845022?pr=144553

<img width="318" height="389" alt="image" src="https://github.com/user-attachments/assets/aa2c0820-469e-4333-8387-fb329ccc943e" /><img width="535" height="372" alt="image" src="https://github.com/user-attachments/assets/e523fe2b-c452-499c-818d-8346d3478697" />


After: https://github.com/hugovk/cpython/actions/runs/21800817629

<img width="307" height="523" alt="image" src="https://github.com/user-attachments/assets/2742f906-68dd-4ac3-a8b6-6597b2137a88" /><img width="540" height="384" alt="image" src="https://github.com/user-attachments/assets/389bdf85-5266-4f53-b038-947aaf9aa783" />
